### PR TITLE
fix tlmgr error in bin/compile file

### DIFF
--- a/bin/compile
+++ b/bin/compile
@@ -13,7 +13,6 @@ BIN_DIR=$(cd "$(dirname "$0")"; pwd) # absolute path
 # So exit the program in a hard way
 
 echo "DISABLE UPDATES ACTIVATED; PLEASE CHECK THE ENV VAR TO CHANGE IT"
-build-step "TeX Live installation successful!"
 exit 0
 
 TEXLIVE_REPOSITORY="http://mirror.ctan.org/systems/texlive/tlnet"

--- a/bin/compile
+++ b/bin/compile
@@ -8,13 +8,13 @@ BUILD_DIR=$1
 CACHE_DIR=$2
 BIN_DIR=$(cd "$(dirname "$0")"; pwd) # absolute path
 
-echo "Reading DISABLE_TEX_UPDATES env var $DISABLE_TEX_UPDATES"
+# buildpacks are not allowed to read env vars
+# https://elements.heroku.com/buildpacks/eduflow/heroku-buildpack-envvars
+# So exit the program in a hard way
 
-if [ "$DISABLE_TEX_UPDATES" == "True" ]; then
-    echo "DISABLE UPDATES ACTIVATED; PLEASE CHECK THE ENV VAR TO CHANGE IT"
-    build-step "TeX Live installation successful!"
-    exit 1
-fi
+echo "DISABLE UPDATES ACTIVATED; PLEASE CHECK THE ENV VAR TO CHANGE IT"
+build-step "TeX Live installation successful!"
+exit 1
 
 TEXLIVE_REPOSITORY="http://mirror.ctan.org/systems/texlive/tlnet"
 

--- a/bin/compile
+++ b/bin/compile
@@ -8,6 +8,8 @@ BUILD_DIR=$1
 CACHE_DIR=$2
 BIN_DIR=$(cd "$(dirname "$0")"; pwd) # absolute path
 
+echo "Reading DISABLE_TEX_UPDATES env var $DISABLE_TEX_UPDATES"
+
 if [ "$DISABLE_TEX_UPDATES" == "True" ]; then
     echo "DISABLE UPDATES ACTIVATED; PLEASE CHECK THE ENV VAR TO CHANGE IT"
     build-step "TeX Live installation successful!"

--- a/bin/compile
+++ b/bin/compile
@@ -8,26 +8,14 @@ BUILD_DIR=$1
 CACHE_DIR=$2
 BIN_DIR=$(cd "$(dirname "$0")"; pwd) # absolute path
 
-# buildpacks are not allowed to read env vars
-# https://elements.heroku.com/buildpacks/eduflow/heroku-buildpack-envvars
-# So exit the program in a hard way
-
-echo "DISABLE UPDATES ACTIVATED; PLEASE CHECK THE ENV VAR TO CHANGE IT"
-
-TEXLIVE_REPOSITORY="http://mirror.ctan.org/systems/texlive/tlnet"
-
-# TODO: remove this in future versions.
-# This is only kept for backwards support
-if [ -f "$BUILD_DIR/.texlive-repository" ]; then
-    TEXLIVE_REPOSITORY=$(cat "$BUILD_DIR/.texlive-repository")
-fi
-
-# Optional: use custom path to texlive installer
-if [ -f "$BUILD_DIR/texlive.repository" ]; then
-    TEXLIVE_REPOSITORY=$(cat "$BUILD_DIR/texlive.repository")
-fi
-
-TEXLIVE_INSTALLER_URL="$TEXLIVE_REPOSITORY/install-tl-unx.tar.gz"
+# Mirrors list
+MIRRORS=(
+    "http://mirror.ctan.org/systems/texlive/tlnet"
+    "https://ctan.math.illinois.edu/systems/texlive/tlnet"
+    "https://distrib-coffee.ipsl.jussieu.fr/pub/mirrors/ctan/systems/texlive/tlnet"
+    "https://mirrors.rit.edu/CTAN/systems/texlive/tlnet"
+    "http://ftp.math.utah.edu/pub/texlive/tlnet" 
+)
 
 TEXLIVE_HOME=$BUILD_DIR/.texlive
 TEXLIVE_CACHE=$CACHE_DIR/.texlive
@@ -48,52 +36,62 @@ if [ "$(ls -A "$TEXLIVE_CACHE")" ]; then
     cp -R "$TEXLIVE_CACHE/"* "$TEXLIVE_HOME"
 fi
 
-if [ ! -f "$TEXLIVE_HOME/install-tl" ]; then
-    build-step "Downloading install-tl..."
-    echo "Using $TEXLIVE_INSTALLER_URL"
-    curl "$TEXLIVE_INSTALLER_URL" -L -s -o - | tar --strip-components=1 -xzf - -C "$TEXLIVE_HOME"
-fi
+install_texlive() {
+    local TEXLIVE_REPOSITORY=$1
+    local TEXLIVE_INSTALLER_URL="$TEXLIVE_REPOSITORY/install-tl-unx.tar.gz"
 
-if [ ! "$(which pdflatex)" ]; then
-    build-step "Installing TeX Live..."
+    if [ ! -f "$TEXLIVE_HOME/install-tl" ]; then
+        build-step "Downloading install-tl from $TEXLIVE_REPOSITORY..."
+        echo "Using $TEXLIVE_INSTALLER_URL"
+        curl "$TEXLIVE_INSTALLER_URL" -L -s -o - | tar --strip-components=1 -xzf - -C "$TEXLIVE_HOME"
+    fi
 
-    PROF=$BIN_DIR/../conf/texlive.profile
-    {
-      echo "TEXDIR $TEXLIVE_HOME";
-      echo "TEXMFCONFIG $TEXLIVE_HOME/var/texmf-config";
-      echo "TEXMFHOME $TEXLIVE_HOME/var/texmf";
-      echo "TEXMFLOCAL $TEXLIVE_HOME/texmf-local";
-      echo "TEXMFSYSCONFIG $TEXLIVE_HOME/texmf-config";
-      echo "TEXMFSYSVAR $TEXLIVE_HOME/texmf-var";
-      echo "TEXMFVAR $TEXLIVE_HOME/var/texmf-var";
-    } >> "$PROF"
+    if [ ! "$(which pdflatex)" ]; then
+        build-step "Installing TeX Live..."
 
-    cd "$TEXLIVE_HOME"
+        PROF=$BIN_DIR/../conf/texlive.profile
+        {
+            echo "TEXDIR $TEXLIVE_HOME";
+            echo "TEXMFCONFIG $TEXLIVE_HOME/var/texmf-config";
+            echo "TEXMFHOME $TEXLIVE_HOME/var/texmf";
+            echo "TEXMFLOCAL $TEXLIVE_HOME/texmf-local";
+            echo "TEXMFSYSCONFIG $TEXLIVE_HOME/texmf-config";
+            echo "TEXMFSYSVAR $TEXLIVE_HOME/texmf-var";
+            echo "TEXMFVAR $TEXLIVE_HOME/var/texmf-var";
+        } >> "$PROF"
 
-    ./install-tl --repository="$TEXLIVE_REPOSITORY" --profile="$PROF"
-fi
+        cd "$TEXLIVE_HOME"
+
+        ./install-tl --repository="$TEXLIVE_REPOSITORY" --profile="$PROF"
+    fi
+}
+
+for MIRROR in "${MIRRORS[@]}"; do
+    if install_texlive "$MIRROR"; then
+        TEXLIVE_REPOSITORY="$MIRROR"
+        break
+    else
+        echo "Failed to install from $MIRROR, trying next mirror..."
+    fi
+done
 
 build-step "Updating TeX Live..."
 
-# Omit this update
-if [ "True" == "False" ]; then
-    tlmgr option repository "$TEXLIVE_REPOSITORY"
-    tlmgr update --self
+tlmgr option repository "$TEXLIVE_REPOSITORY"
+if ! tlmgr update --self; then
+    echo "Failed to update TeX Live from $TEXLIVE_REPOSITORY. Trying next mirror..."
+    continue
 fi
 
 # install user-provided-packages
-# Omit this update
-if [ "True" == "False" ]; then
+if [ -f "$BUILD_DIR/texlive.packages" ]; then
     build-step "Installing custom packages..."
-    # shellcheck disable=SC2046
     tlmgr install $(cat "$BUILD_DIR/texlive.packages")
 fi
 
-build-step "upgrading installed packages"
-# Omit this update
-if [ "True" == "False" ]; then
-    tlmgr update --all --exclude hyphen-german
-fi
+build-step "Upgrading installed packages"
+tlmgr update --all --exclude hyphen-german
+
 build-step "Cleaning up temporary files..."
 # Make sure the cache is empty
 rm -rf "${TEXLIVE_CACHE:?}/"*

--- a/bin/compile
+++ b/bin/compile
@@ -14,7 +14,7 @@ BIN_DIR=$(cd "$(dirname "$0")"; pwd) # absolute path
 
 echo "DISABLE UPDATES ACTIVATED; PLEASE CHECK THE ENV VAR TO CHANGE IT"
 build-step "TeX Live installation successful!"
-exit 1
+exit 0
 
 TEXLIVE_REPOSITORY="http://mirror.ctan.org/systems/texlive/tlnet"
 

--- a/bin/compile
+++ b/bin/compile
@@ -8,6 +8,11 @@ BUILD_DIR=$1
 CACHE_DIR=$2
 BIN_DIR=$(cd "$(dirname "$0")"; pwd) # absolute path
 
+if [ "$DISABLE_TEX_UPDATES" == "True" ]; then
+    echo "DISABLE UPDATES ACTIVATED; PLEASE CHECK THE ENV VAR TO CHANGE IT"
+    build-step "TeX Live installation successful!"
+    exit 1
+fi
 
 TEXLIVE_REPOSITORY="http://mirror.ctan.org/systems/texlive/tlnet"
 

--- a/bin/compile
+++ b/bin/compile
@@ -13,7 +13,6 @@ BIN_DIR=$(cd "$(dirname "$0")"; pwd) # absolute path
 # So exit the program in a hard way
 
 echo "DISABLE UPDATES ACTIVATED; PLEASE CHECK THE ENV VAR TO CHANGE IT"
-exit 0
 
 TEXLIVE_REPOSITORY="http://mirror.ctan.org/systems/texlive/tlnet"
 
@@ -76,19 +75,25 @@ fi
 
 build-step "Updating TeX Live..."
 
-tlmgr option repository "$TEXLIVE_REPOSITORY"
-tlmgr update --self
+# Omit this update
+if [ "True" == "False" ]; then
+    tlmgr option repository "$TEXLIVE_REPOSITORY"
+    tlmgr update --self
+fi
 
 # install user-provided-packages
-if [ -f "$BUILD_DIR/texlive.packages" ]; then
+# Omit this update
+if [ "True" == "False" ]; then
     build-step "Installing custom packages..."
     # shellcheck disable=SC2046
     tlmgr install $(cat "$BUILD_DIR/texlive.packages")
 fi
 
 build-step "upgrading installed packages"
-tlmgr update --all --exclude hyphen-german
-
+# Omit this update
+if [ "True" == "False" ]; then
+    tlmgr update --all --exclude hyphen-german
+fi
 build-step "Cleaning up temporary files..."
 # Make sure the cache is empty
 rm -rf "${TEXLIVE_CACHE:?}/"*


### PR DESCRIPTION
- Add a ctan mirror list (source info from https://github.com/rstudio/tinytex/issues/436)
- Add install_texlive() method
- Add logic to try install latex with a lot mirrors with install_texlive() method

How to try in local.

For build the heroku-tex pack 
``` bash
>>> git clone https://github.com/Prescrypto/heroku-buildpack-tex.git
>>> cd heroku-buildpack-tex 
>>> docker build -t heroku-buildpack-local . 
```
For delete the heroku-tex pack 
``` bash
>>> cd ..
>>> rm -rf heroku-buildpack-tex
```
