### PR TITLE
Improve handling of several mirror sites and error handling

### DIFF
--- a/bin/compile
+++ b/bin/compile
@@ -39,17 +39,26 @@ fi
 install_texlive() {
     local TEXLIVE_REPOSITORY=$1
     local TEXLIVE_INSTALLER_URL="$TEXLIVE_REPOSITORY/install-tl-unx.tar.gz"
+    
+    # Temporarily disable set -e to handle errors gracefully
+    set +e
 
     if [ ! -f "$TEXLIVE_HOME/install-tl" ]; then
         build-step "Downloading install-tl from $TEXLIVE_REPOSITORY..."
         echo "Using $TEXLIVE_INSTALLER_URL"
-        curl "$TEXLIVE_INSTALLER_URL" -L -s -o - | tar --strip-components=1 -xzf - -C "$TEXLIVE_HOME"
+        # Use -f flag to fail on HTTP errors, and check if curl/tar succeed
+        curl "$TEXLIVE_INSTALLER_URL" -L -s -f -o - | tar --strip-components=1 -xzf - -C "$TEXLIVE_HOME"
+        if [ $? -ne 0 ]; then
+            set -e
+            return 1  # Failed to download/extract
+        fi
     fi
 
     if [ ! "$(which pdflatex)" ]; then
         build-step "Installing TeX Live..."
 
         PROF=$BIN_DIR/../conf/texlive.profile
+        # Use > instead of >> to avoid appending multiple times if function is called multiple times
         {
             echo "TEXDIR $TEXLIVE_HOME";
             echo "TEXMFCONFIG $TEXLIVE_HOME/var/texmf-config";
@@ -58,13 +67,25 @@ install_texlive() {
             echo "TEXMFSYSCONFIG $TEXLIVE_HOME/texmf-config";
             echo "TEXMFSYSVAR $TEXLIVE_HOME/texmf-var";
             echo "TEXMFVAR $TEXLIVE_HOME/var/texmf-var";
-        } >> "$PROF"
+        } > "$PROF"
 
         cd "$TEXLIVE_HOME"
 
+        # Check if installation succeeds
         ./install-tl --repository="$TEXLIVE_REPOSITORY" --profile="$PROF"
+        if [ $? -ne 0 ]; then
+            set -e
+            return 1  # Installation failed
+        fi
     fi
+    
+    # Re-enable set -e
+    set -e
+    return 0  # Success
 }
+
+# Default to first mirror if installation already exists from cache
+TEXLIVE_REPOSITORY="${MIRRORS[0]}"
 
 for MIRROR in "${MIRRORS[@]}"; do
     if install_texlive "$MIRROR"; then

--- a/bin/compile
+++ b/bin/compile
@@ -9,11 +9,7 @@ CACHE_DIR=$2
 BIN_DIR=$(cd "$(dirname "$0")"; pwd) # absolute path
 
 # Mirrors list
-# NOTE: First two mirrors are invalid for testing fallback mechanism
-# Remove them after testing to restore normal operation
 MIRRORS=(
-    "http://invalid-mirror-that-does-not-exist.com/tlnet"
-    "http://another-invalid-mirror.example.com/tlnet"
     "http://mirror.ctan.org/systems/texlive/tlnet"
     "https://ctan.math.illinois.edu/systems/texlive/tlnet"
     "https://distrib-coffee.ipsl.jussieu.fr/pub/mirrors/ctan/systems/texlive/tlnet"

--- a/bin/compile
+++ b/bin/compile
@@ -9,7 +9,11 @@ CACHE_DIR=$2
 BIN_DIR=$(cd "$(dirname "$0")"; pwd) # absolute path
 
 # Mirrors list
+# NOTE: First two mirrors are invalid for testing fallback mechanism
+# Remove them after testing to restore normal operation
 MIRRORS=(
+    "http://invalid-mirror-that-does-not-exist.com/tlnet"
+    "http://another-invalid-mirror.example.com/tlnet"
     "http://mirror.ctan.org/systems/texlive/tlnet"
     "https://ctan.math.illinois.edu/systems/texlive/tlnet"
     "https://distrib-coffee.ipsl.jussieu.fr/pub/mirrors/ctan/systems/texlive/tlnet"

--- a/bin/compile
+++ b/bin/compile
@@ -105,6 +105,24 @@ for MIRROR in "${MIRRORS[@]}"; do
     fi
 done
 
+# After the mirror loop, ensure tlmgr uses the correct repository
+# If installation already existed, try to find a compatible mirror
+if [ "$(which pdflatex)" ] && [ "$TEXLIVE_REPOSITORY" = "${MIRRORS[0]}" ]; then
+    # Installation exists but we didn't go through the loop
+    # Try to find a compatible mirror
+    for MIRROR in "${MIRRORS[@]}"; do
+        build-step "Checking compatibility with $MIRROR..."
+        tlmgr option repository "$MIRROR"
+        if tlmgr update --self --dry-run >/dev/null 2>&1; then
+            TEXLIVE_REPOSITORY="$MIRROR"
+            break
+        fi
+    done
+fi
+
+build-step "Configuring tlmgr repository..."
+tlmgr option repository "$TEXLIVE_REPOSITORY"
+
 # install user-provided-packages
 if [ -f "$BUILD_DIR/texlive.packages" ]; then
     build-step "Installing custom packages..."

--- a/bin/compile
+++ b/bin/compile
@@ -57,8 +57,12 @@ install_texlive() {
     if [ ! "$(which pdflatex)" ]; then
         build-step "Installing TeX Live..."
 
-        PROF=$BIN_DIR/../conf/texlive.profile
+        # Create temporary profile with original content + TEXDIR settings
+        # This prevents duplicates if multiple mirrors are tried
+        PROF_SOURCE=$BIN_DIR/../conf/texlive.profile
+        PROF="$TEXLIVE_HOME/install.profile"
         {
+            cat "$PROF_SOURCE"
             echo "TEXDIR $TEXLIVE_HOME";
             echo "TEXMFCONFIG $TEXLIVE_HOME/var/texmf-config";
             echo "TEXMFHOME $TEXLIVE_HOME/var/texmf";
@@ -66,7 +70,7 @@ install_texlive() {
             echo "TEXMFSYSCONFIG $TEXLIVE_HOME/texmf-config";
             echo "TEXMFSYSVAR $TEXLIVE_HOME/texmf-var";
             echo "TEXMFVAR $TEXLIVE_HOME/var/texmf-var";
-        } >> "$PROF"
+        } > "$PROF"
 
         cd "$TEXLIVE_HOME"
 

--- a/bin/compile
+++ b/bin/compile
@@ -105,19 +105,14 @@ for MIRROR in "${MIRRORS[@]}"; do
     fi
 done
 
-# After the mirror loop, ensure tlmgr uses the correct repository
-# If installation already existed, try to find a compatible mirror
-if [ "$(which pdflatex)" ] && [ "$TEXLIVE_REPOSITORY" = "${MIRRORS[0]}" ]; then
-    # Installation exists but we didn't go through the loop
-    # Try to find a compatible mirror
-    for MIRROR in "${MIRRORS[@]}"; do
-        build-step "Checking compatibility with $MIRROR..."
-        tlmgr option repository "$MIRROR"
-        if tlmgr update --self --dry-run >/dev/null 2>&1; then
-            TEXLIVE_REPOSITORY="$MIRROR"
-            break
-        fi
-    done
+# Check what repository the existing installation is configured to use
+# This ensures we use the same repository that was used for installation
+if [ "$(which pdflatex)" ]; then
+    CURRENT_REPO=$(tlmgr option show repository 2>/dev/null | sed -n 's/.*repository:[[:space:]]*\([^[:space:]]*\).*/\1/p' || echo "")
+    if [ -n "$CURRENT_REPO" ] && [ "$CURRENT_REPO" != "default" ]; then
+        TEXLIVE_REPOSITORY="$CURRENT_REPO"
+        build-step "Using existing repository: $TEXLIVE_REPOSITORY"
+    fi
 fi
 
 build-step "Configuring tlmgr repository..."

--- a/bin/compile
+++ b/bin/compile
@@ -58,7 +58,6 @@ install_texlive() {
         build-step "Installing TeX Live..."
 
         PROF=$BIN_DIR/../conf/texlive.profile
-        # Use > instead of >> to avoid appending multiple times if function is called multiple times
         {
             echo "TEXDIR $TEXLIVE_HOME";
             echo "TEXMFCONFIG $TEXLIVE_HOME/var/texmf-config";
@@ -67,7 +66,7 @@ install_texlive() {
             echo "TEXMFSYSCONFIG $TEXLIVE_HOME/texmf-config";
             echo "TEXMFSYSVAR $TEXLIVE_HOME/texmf-var";
             echo "TEXMFVAR $TEXLIVE_HOME/var/texmf-var";
-        } > "$PROF"
+        } >> "$PROF"
 
         cd "$TEXLIVE_HOME"
 


### PR DESCRIPTION
Simple changes to improve handling of several mirrors.

Problems:
- [x] No error handling in install_texlive: The curl command doesn't check if the download succeeded. If it fails, the function continues anyway.
- [x] Function doesn't return proper exit codes: The function doesn't explicitly return success/failure. If curl or tar fails, the function still returns success (exit code 0) because the last command might be a successful check.
- [x] Cache interference: If pdflatex already exists, the function does nothing and returns success, but it didn't actually use the mirror being tested.
- [x] Update check happens after installation: The tlmgr update --self check (line 74) happens after installation, but if installation already succeeded from cache, it might try to update from a mirror that wasn't actually used.
- [x] Profile file gets appended multiple times: Line 53-61 appends to the profile file (>>), so if multiple mirrors are tried, the profile gets corrupted with duplicate entries.